### PR TITLE
Move vite from devDependencies in client/package.json, test 'npm run …

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.19.0",
     "react-svg": "^16.1.31",
+    "vite": "^5.0.0",
     "three": "^0.158.0"
   },
   "devDependencies": {
@@ -32,7 +33,6 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.4",
-    "vite": "^5.0.0",
     "vite-plugin-svgr": "^4.2.0"
   }
 }


### PR DESCRIPTION
…develop' afterwords, confirmed to work as it did previously. This is intended to fix Heroku not being able to build the app when I test the deployment.