### PR TITLE
Move @vitejs/plugin-react to dependencies the same as the last bugfix…

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,13 +22,13 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.19.0",
     "react-svg": "^16.1.31",
+    "@vitejs/plugin-react": "^4.2.0",
     "vite": "^5.0.0",
     "three": "^0.158.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
-    "@vitejs/plugin-react": "^4.2.0",
     "eslint": "^8.53.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",


### PR DESCRIPTION
… branch. This should hopefully be the last tech that was missing from the Heroku build process.